### PR TITLE
fix: Better pytest fixture handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,4 +12,7 @@ pyright:
 test:
 	uv run pytest
 
+testx:
+	uv run pytest -x --pdb
+
 rpt: ruff pyright test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sdsort"
-version = "0.3.0"
+version = "0.3.1"
 description = "Sorts functions and class methods according to the step-down rule"
 authors = [{ name = "Eiríkur Fannar Torfason", email = "eirikur.torfason@gmail.com" }]
 requires-python = ">= 3.10"

--- a/test/cases/pytest_fixtures.in.py
+++ b/test/cases/pytest_fixtures.in.py
@@ -1,5 +1,9 @@
 import pytest
 
+def do_stuff():
+    print("doing")
+
+
 @pytest.fixture
 def prepare_stuff():
     def _inner():
@@ -7,6 +11,8 @@ def prepare_stuff():
     
     return _inner
 
+
 def test_something(prepare_stuff):
     x = prepare_stuff()
+    do_stuff()
     assert x > 0

--- a/test/cases/pytest_fixtures.out.py
+++ b/test/cases/pytest_fixtures.out.py
@@ -7,6 +7,12 @@ def prepare_stuff():
     
     return _inner
 
+
 def test_something(prepare_stuff):
     x = prepare_stuff()
+    do_stuff()
     assert x > 0
+
+
+def do_stuff():
+    print("doing")

--- a/uv.lock
+++ b/uv.lock
@@ -138,7 +138,7 @@ wheels = [
 
 [[package]]
 name = "sdsort"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Ignore pytest fixtures during dependency discovery, rather than during function discovery.