### PR TITLE
fix: New top level sort alg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,6 @@ test:
 	uv run pytest
 
 testx:
-	uv run pytest -x --pdb
+	uv run pytest -x --pdb -vv
 
 rpt: ruff pyright test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sdsort"
-version = "0.3.1"
+version = "0.4.0"
 description = "Sorts functions and class methods according to the step-down rule"
 authors = [{ name = "Eiríkur Fannar Torfason", email = "eirikur.torfason@gmail.com" }]
 requires-python = ">= 3.10"

--- a/sdsort/__init__.py
+++ b/sdsort/__init__.py
@@ -316,22 +316,24 @@ def _find_dependencies(
 ) -> dict[str, list[str]]:
     """Find dependencies between functions/methods based on call patterns.
 
-    Note: For top-level functions, decorators are not included as dependencies.
-    Decorators must be defined before use (syntactic constraint), but for step-down
-    ordering, the decorated function should come before its decorator.
+    Note: decorator_list is excluded from the walk. Decorator arguments are evaluated
+    at definition time, so any functions they call must already be defined before the
+    decorated function — treating them as step-down dependencies would invert that.
     """
     dependencies: dict[str, list[str]] = defaultdict(list)
     for func in funcs.values():
-        for node in walk(func):
-            if isinstance(node, Call):
-                target = get_call_target(node)
-                if (
-                    target is not None
-                    and target in funcs
-                    and not _is_pytest_fixture(funcs[target])
-                    and target not in dependencies[func.name]
-                ):
-                    dependencies[func.name].append(target)
+        subtrees = [*func.body, func.args, *([] if func.returns is None else [func.returns])]
+        for subtree in subtrees:
+            for node in walk(subtree):
+                if isinstance(node, Call):
+                    target = get_call_target(node)
+                    if (
+                        target is not None
+                        and target in funcs
+                        and not _is_pytest_fixture(funcs[target])
+                        and target not in dependencies[func.name]
+                    ):
+                        dependencies[func.name].append(target)
     return dependencies
 
 

--- a/sdsort/__init__.py
+++ b/sdsort/__init__.py
@@ -2,7 +2,6 @@ import os
 import time
 from ast import AST, AsyncFunctionDef, Attribute, Call, ClassDef, FunctionDef, Module, Name, parse, walk
 from collections import defaultdict
-from dataclasses import dataclass
 from glob import glob
 from typing import Callable, Iterable, Optional, Protocol, TypeGuard, Union
 
@@ -253,63 +252,43 @@ def _group_by_zone(
     return [z for z in zones if z]
 
 
-@dataclass
-class Segment:
-    start: int
-    stop: int
-
-    @property
-    def is_valid(self):
-        return self.stop >= self.start
-
-
-@dataclass
-class FunctionSegment(Segment):
-    name: str
-    node: FunDef
-
-
 def _rearrange_top_level_functions(
     source_lines: list[str],
     func_dict: dict[str, FunDef],
     sorted_dict: dict[str, FunDef],
 ) -> list[str]:
-    function_ranges = [_determine_line_range(f, source_lines) for f in func_dict.values()]
-    function_segments = {
-        name: FunctionSegment(start=start, stop=stop, name=name, node=node)
-        for ((name, node), (start, stop)) in zip(func_dict.items(), function_ranges)
-    }
-    all_segments: list[Segment] = []
-    for fun_seg in function_segments.values():
-        filler = Segment(start=0 if len(all_segments) == 0 else all_segments[-1].stop + 1, stop=fun_seg.start - 1)
-        if filler.is_valid:
-            all_segments.append(filler)
-        all_segments.append(fun_seg)
-    filler = Segment(start=all_segments[-1].stop + 1, stop=len(source_lines) - 1)
-    if filler.is_valid:
-        all_segments.append(filler)
+    # Pre-compute all line ranges up front.
+    ranges = {name: _determine_line_range(node, source_lines) for name, node in func_dict.items()}
+
+    def lines_of(name: str) -> list[str]:
+        start, stop = ranges[name]
+        return source_lines[start : stop + 1]
 
     result: list[str] = []
+    pos = 0
+    sorted_names = list(sorted_dict.keys())
+    sort_idx = 0
 
-    def append_segment(segment: Segment):
-        result.extend(source_lines[segment.start : segment.stop + 1])
+    for orig_name in func_dict:
+        orig_start, orig_stop = ranges[orig_name]
+        result.extend(source_lines[pos : orig_start])  # filler is always emitted in original order
+        pos = orig_stop + 1
 
-    sorted_function_stack = list(reversed(sorted_dict.keys()))
-    for segment in all_segments:
-        if isinstance(segment, FunctionSegment):
-            if segment.name == sorted_function_stack[-1]:
-                append_segment(segment)
-                sorted_function_stack.pop()
-                prev = segment
-                while (
-                    len(sorted_function_stack) > 0
-                    and (past_segment := function_segments[sorted_function_stack[-1]]).start < prev.start
-                ):
-                    append_segment(past_segment)
-                    sorted_function_stack.pop()
-        else:
-            append_segment(segment)
+        if sort_idx >= len(sorted_names) or orig_name != sorted_names[sort_idx]:
+            # The next sorted function hasn't reached its trigger slot yet; skip this slot.
+            # Functions emitted early by the while-loop below also land here.
+            continue
 
+        result.extend(lines_of(sorted_names[sort_idx]))
+        sort_idx += 1
+
+        # A function that originally appeared before this slot should follow it immediately,
+        # because its own slot was already passed (and skipped) earlier in the walk.
+        while sort_idx < len(sorted_names) and ranges[sorted_names[sort_idx]][0] < orig_start:
+            result.extend(lines_of(sorted_names[sort_idx]))
+            sort_idx += 1
+
+    result.extend(source_lines[pos:])  # trailing content
     return result
 
 

--- a/sdsort/__init__.py
+++ b/sdsort/__init__.py
@@ -2,6 +2,7 @@ import os
 import time
 from ast import AST, AsyncFunctionDef, Attribute, Call, ClassDef, FunctionDef, Module, Name, parse, walk
 from collections import defaultdict
+from dataclasses import dataclass
 from glob import glob
 from typing import Callable, Iterable, Optional, Protocol, TypeGuard, Union
 
@@ -91,9 +92,77 @@ def step_down_sort(python_file_path: str) -> Optional[str]:
     final_lines.extend(modified_lines[len(final_lines) :])
 
     if source_lines != final_lines:
-        return "\n".join(final_lines) + "\n"
+        return _normalize_blank_lines(final_lines)
     else:
         return None
+
+
+def _normalize_blank_lines(lines: list[str]) -> str:
+    """Normalize blank lines per PEP 8:
+    - 2 blank lines before top-level function/class definitions
+    - 1 blank line between methods in a class (0 before the first)
+    """
+    # Collect 0-based line indices where PEP 8 spacing rules apply
+    # Maps line_index -> required number of preceding blank lines
+    required_blanks: dict[int, int] = {}
+    tree = parse("\n".join(lines) + "\n")
+
+    for node in tree.body:
+        if isinstance(node, (FunctionDef, AsyncFunctionDef, ClassDef)):
+            target = min((d.lineno for d in node.decorator_list), default=node.lineno)
+            # Scan backwards past any leading comments so the 2 blank lines are
+            # inserted before the comment block, not between the comment and the def.
+            marker = target - 1  # 0-based index of the def/decorator line
+            while marker > 0 and lines[marker - 1].strip().startswith("#"):
+                marker -= 1
+            required_blanks[marker] = 2
+
+    for node in tree.body:
+        if not isinstance(node, ClassDef):
+            continue
+        methods = [n for n in node.body if isinstance(n, (FunctionDef, AsyncFunctionDef))]
+        for i, method in enumerate(methods):
+            target = min((d.lineno for d in method.decorator_list), default=method.lineno)
+            if i == 0:
+                # For the first method, preserve existing blank lines (up to 1) rather
+                # than forcing 0 — this allows a blank between class variables and the
+                # first method when the author already wrote one.
+                preceding_blanks = 0
+                for line_idx in range(target - 2, -1, -1):
+                    if lines[line_idx].strip() == "":
+                        preceding_blanks += 1
+                    else:
+                        break
+                required_blanks[target - 1] = min(preceding_blanks, 1)
+            else:
+                required_blanks[target - 1] = 1  # 0-based
+
+    # Walk lines, stripping existing blank lines before def sites
+    # and injecting the required number
+    result: list[str] = []
+    i = 0
+    while i < len(lines):
+        if i in required_blanks:
+            # Strip any blank lines already accumulated at the end of result
+            while result and result[-1].strip() == "":
+                result.pop()
+            # Inject the required blank lines
+            result.extend([""] * required_blanks[i])
+        line = lines[i]
+        # Cap consecutive blank lines at 2 (PEP 8) for lines not controlled by required_blanks
+        if (
+            i not in required_blanks
+            and line.strip() == ""
+            and len(result) >= 2
+            and result[-1].strip() == ""
+            and result[-2].strip() == ""
+        ):
+            i += 1
+            continue
+        result.append(line)
+        i += 1
+
+    return "\n".join(result).strip() + "\n"
 
 
 def _read_file(file_path: str) -> str:
@@ -184,14 +253,63 @@ def _group_by_zone(
     return [z for z in zones if z]
 
 
+@dataclass
+class Segment:
+    start: int
+    stop: int
+
+    @property
+    def is_valid(self):
+        return self.stop >= self.start
+
+
+@dataclass
+class FunctionSegment(Segment):
+    name: str
+    node: FunDef
+
+
 def _rearrange_top_level_functions(
     source_lines: list[str],
     func_dict: dict[str, FunDef],
     sorted_dict: dict[str, FunDef],
 ) -> list[str]:
-    """Rearrange top-level code with sorted functions."""
-    result, pos = _rearrange_functions(source_lines, func_dict, sorted_dict)
-    result.extend(source_lines[pos:])
+    function_ranges = [_determine_line_range(f, source_lines) for f in func_dict.values()]
+    function_segments = {
+        name: FunctionSegment(start=start, stop=stop, name=name, node=node)
+        for ((name, node), (start, stop)) in zip(func_dict.items(), function_ranges)
+    }
+    all_segments: list[Segment] = []
+    for fun_seg in function_segments.values():
+        filler = Segment(start=0 if len(all_segments) == 0 else all_segments[-1].stop + 1, stop=fun_seg.start - 1)
+        if filler.is_valid:
+            all_segments.append(filler)
+        all_segments.append(fun_seg)
+    filler = Segment(start=all_segments[-1].stop + 1, stop=len(source_lines) - 1)
+    if filler.is_valid:
+        all_segments.append(filler)
+
+    result: list[str] = []
+
+    def append_segment(segment: Segment):
+        result.extend(source_lines[segment.start : segment.stop + 1])
+
+    sorted_function_stack = list(reversed(sorted_dict.keys()))
+    for segment in all_segments:
+        if isinstance(segment, FunctionSegment):
+            if segment.name == sorted_function_stack[-1]:
+                append_segment(segment)
+                sorted_function_stack.pop()
+                prev = segment
+                while (
+                    len(sorted_function_stack) > 0
+                    and (past_segment := function_segments[sorted_function_stack[-1]]).start < prev.start
+                ):
+                    append_segment(past_segment)
+                    sorted_function_stack.pop()
+        else:
+            append_segment(segment)
+
     return result
 
 
@@ -319,6 +437,12 @@ def _determine_line_range(method: FunDef, source_lines: list[str]) -> tuple[int,
     while peek.strip().startswith("#"):
         start -= 1
         peek = source_lines[start - 1] if start > 0 else ""
+
+    # Include leading whitespace, at least up to a point?
+    # peek = source_lines[start - 1] if start > 0 else "nope"
+    # while len(peek.strip()) == 0:
+    #    start -= 1
+    #    peek = source_lines[start - 1] if start > 0 else "nope"
 
     stop = max(n.lineno for n in walk(method) if has_lineno(n))
 

--- a/sdsort/__init__.py
+++ b/sdsort/__init__.py
@@ -271,7 +271,7 @@ def _rearrange_top_level_functions(
 
     for orig_name in func_dict:
         orig_start, orig_stop = ranges[orig_name]
-        result.extend(source_lines[pos : orig_start])  # filler is always emitted in original order
+        result.extend(source_lines[pos:orig_start])  # filler is always emitted in original order
         pos = orig_stop + 1
 
         if sort_idx >= len(sorted_names) or orig_name != sorted_names[sort_idx]:
@@ -418,12 +418,6 @@ def _determine_line_range(method: FunDef, source_lines: list[str]) -> tuple[int,
     while peek.strip().startswith("#"):
         start -= 1
         peek = source_lines[start - 1] if start > 0 else ""
-
-    # Include leading whitespace, at least up to a point?
-    # peek = source_lines[start - 1] if start > 0 else "nope"
-    # while len(peek.strip()) == 0:
-    #    start -= 1
-    #    peek = source_lines[start - 1] if start > 0 else "nope"
 
     stop = max(n.lineno for n in walk(method) if has_lineno(n))
 

--- a/test/cases/parametrized_test.in.py
+++ b/test/cases/parametrized_test.in.py
@@ -1,0 +1,25 @@
+import pytest
+from sut import _calculate_score 
+
+
+def generate_test_case(scenario: str):
+    return str(reversed(scenario))
+
+
+@pytest.mark.parametrize(
+    "task,expected_score",
+    [
+        (generate_test_case("easy"), 95),
+        (generate_test_case("medium"), 75),
+        (generate_test_case("hard"), 65),
+    ],
+)
+def test__calculate_score(
+    task: str,
+    expected_score: int,
+):
+    # Act
+    score = _calculate_score(task)
+
+    # Assert
+    assert score == expected_score

--- a/test/cases/parametrized_test.out.py
+++ b/test/cases/parametrized_test.out.py
@@ -1,0 +1,25 @@
+import pytest
+from sut import _calculate_score 
+
+
+def generate_test_case(scenario: str):
+    return str(reversed(scenario))
+
+
+@pytest.mark.parametrize(
+    "task,expected_score",
+    [
+        (generate_test_case("easy"), 95),
+        (generate_test_case("medium"), 75),
+        (generate_test_case("hard"), 65),
+    ],
+)
+def test__calculate_score(
+    task: str,
+    expected_score: int,
+):
+    # Act
+    score = _calculate_score(task)
+
+    # Assert
+    assert score == expected_score

--- a/test/cases/pytest_fixtures.in.py
+++ b/test/cases/pytest_fixtures.in.py
@@ -1,5 +1,6 @@
 import pytest
 
+
 def do_stuff():
     print("doing")
 

--- a/test/cases/pytest_fixtures.out.py
+++ b/test/cases/pytest_fixtures.out.py
@@ -1,5 +1,6 @@
 import pytest
 
+
 @pytest.fixture
 def prepare_stuff():
     def _inner():

--- a/test/cases/sandwiched_decorator.in.py
+++ b/test/cases/sandwiched_decorator.in.py
@@ -1,0 +1,46 @@
+from functools import cache
+
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import HTMLResponse
+from fastapi.security import HTTPBasic
+
+
+e2e_secret_path = "/some/secret/path"
+
+
+@cache
+def read_e2e_password_from_file():
+    return e2e_secret_path.read_text().strip()
+
+
+e2e_app = FastAPI(
+    root_path="/api/e2e",
+    openapi_tags=[{"name": "E2E", "description": "Test Automation Service"}],
+    docs_url=None,
+    redoc_url=None,
+)
+
+security = HTTPBasic()
+
+
+@e2e_app.middleware("http")
+async def auth(request: Request, call_next):
+    # Allow access if the request is for the OpenAPI spec
+    if request.url.path == f"{e2e_app.root_path}{e2e_app.openapi_url}":
+        return await call_next(request)
+
+    password = read_e2e_password_from_file()
+    credentials = None
+    try:
+        credentials = await security(request)
+    except HTTPException:
+        pass
+    if (
+        credentials is not None
+        and password is not None
+        and credentials.username == "e2e"
+        and credentials.password == password
+    ):
+        return await call_next(request)
+
+    return HTMLResponse(content="Unauthorized", status_code=401)

--- a/test/cases/sandwiched_decorator.out.py
+++ b/test/cases/sandwiched_decorator.out.py
@@ -1,0 +1,46 @@
+from functools import cache
+
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import HTMLResponse
+from fastapi.security import HTTPBasic
+
+
+e2e_secret_path = "/some/secret/path"
+
+
+e2e_app = FastAPI(
+    root_path="/api/e2e",
+    openapi_tags=[{"name": "E2E", "description": "Test Automation Service"}],
+    docs_url=None,
+    redoc_url=None,
+)
+
+security = HTTPBasic()
+
+
+@e2e_app.middleware("http")
+async def auth(request: Request, call_next):
+    # Allow access if the request is for the OpenAPI spec
+    if request.url.path == f"{e2e_app.root_path}{e2e_app.openapi_url}":
+        return await call_next(request)
+
+    password = read_e2e_password_from_file()
+    credentials = None
+    try:
+        credentials = await security(request)
+    except HTTPException:
+        pass
+    if (
+        credentials is not None
+        and password is not None
+        and credentials.username == "e2e"
+        and credentials.password == password
+    ):
+        return await call_next(request)
+
+    return HTMLResponse(content="Unauthorized", status_code=401)
+
+
+@cache
+def read_e2e_password_from_file():
+    return e2e_secret_path.read_text().strip()

--- a/test/test_sdsort.py
+++ b/test/test_sdsort.py
@@ -28,6 +28,7 @@ TEST_CASES_DIR = "test/cases"
         "multiple_barriers",
         "pytest_fixtures",
         "sandwiched_decorator",
+        "parametrized_test",
     ],
 )
 def test_all_cases(test_case: str):

--- a/test/test_sdsort.py
+++ b/test/test_sdsort.py
@@ -27,6 +27,7 @@ TEST_CASES_DIR = "test/cases"
         "circular_functions",
         "multiple_barriers",
         "pytest_fixtures",
+        "sandwiched_decorator",
     ],
 )
 def test_all_cases(test_case: str):

--- a/uv.lock
+++ b/uv.lock
@@ -138,7 +138,7 @@ wheels = [
 
 [[package]]
 name = "sdsort"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
- Rewrite the top-level function rearrangement algorithm to be more conservative. Instead of swapping functions, thus potentially moving a function above code that relied on it, pull dependents down below dependees as needed.
- Fix dependency detection for decorator arguments: decorators are now excluded from the dependency walk, since decorator callables must already be defined before the decorated function — treating them as step-down dependencies would invert the correct order
- Add a `_normalize_blank_lines` post-processing step that enforces PEP 8 spacing (2 blank lines before top-level definitions, 1 between class methods) after reordering
- Add two new test cases: sandwiched_decorator (the motivating bug) and parametrized_test (pytest parametrize with a helper called inside the decorator arguments)
