### PR TITLE
fix: Error reading files on windows that contain non-ascii characters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Lint
         run: |
-          uv run ruff check --select I
+          uv run ruff check
           uv run ruff format --check
 
       - name: Type check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,3 +53,18 @@ jobs:
         run: uv run pytest
         env:
           UV_PYTHON: ${{ matrix.python-version }}
+
+  test-windows:
+    runs-on: windows-latest
+    env:
+      UV_PYTHON: '3.14'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+      
+      - name: Test
+        run: uv run pytest

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL := /bin/bash
 .PHONY: test
 
 ruff:
-	uv run ruff check --select I --fix
+	uv run ruff check --fix
 	uv run ruff format
 
 pyright:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,9 +35,13 @@ requires = ["uv_build>=0.11.3,<0.12"]
 build-backend = "uv_build"
 
 [tool.ruff]
+include = ["sdsort/**/*.py", "test/**/*.py"]
 exclude = ["test/cases"]
 line-length = 115
 target-version = "py310"
+
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F", "I"]
 
 [tool.pyright]
 include = ["sdsort", "test"]

--- a/sdsort/cli.py
+++ b/sdsort/cli.py
@@ -48,7 +48,7 @@ def _sort_files(file_paths: list[str], check: bool):
         modified_source = step_down_sort(file_path)
         if modified_source is not None:
             if not check:
-                with open(file_path, "w") as file:
+                with open(file_path, "w", encoding="utf-8") as file:
                     file.write(modified_source)
             results.modified_files.append(file_path)
         else:

--- a/sdsort/format.py
+++ b/sdsort/format.py
@@ -1,4 +1,4 @@
-from ast import AsyncFunctionDef, ClassDef, FunctionDef, Module, parse
+from ast import Module, parse
 
 from .utils.ast import find_first_line, get_class_nodes, get_function_and_class_nodes, get_method_nodes, is_blank
 

--- a/sdsort/sort.py
+++ b/sdsort/sort.py
@@ -1,5 +1,6 @@
 from ast import AsyncFunctionDef, Attribute, Call, ClassDef, FunctionDef, Module, Name, parse, walk
 from collections import defaultdict
+from pathlib import Path
 from typing import Callable, Iterable, Optional
 
 from .format import normalize_blank_lines
@@ -7,7 +8,7 @@ from .utils.ast import Function, determine_line_range, get_class_nodes, get_meth
 from .utils.file import read_file
 
 
-def step_down_sort(python_file_path: str) -> Optional[str]:
+def step_down_sort(python_file_path: str | Path) -> Optional[str]:
     source = read_file(python_file_path)
     syntax_tree = parse(source, filename=python_file_path)
     source_lines = source.splitlines()

--- a/sdsort/utils/file.py
+++ b/sdsort/utils/file.py
@@ -1,5 +1,8 @@
+import tokenize
+
+
 def read_file(file_path: str) -> str:
-    with open(file_path) as f:
+    with tokenize.open(file_path) as f:
         source = f.read()
     return normalize_line_endings(source)
 

--- a/sdsort/utils/file.py
+++ b/sdsort/utils/file.py
@@ -1,14 +1,3 @@
-import tokenize
-
-
 def read_file(file_path: str) -> str:
-    with tokenize.open(file_path) as f:
-        source = f.read()
-    return normalize_line_endings(source)
-
-
-def normalize_line_endings(input: str):
-    result = input.replace("\r\n", "\n").replace("\r", "\n")
-    if not result.endswith("\n"):
-        result += "\n"
-    return result
+    with open(file_path, encoding="utf-8", newline=None) as f:
+        return f.read()

--- a/sdsort/utils/file.py
+++ b/sdsort/utils/file.py
@@ -1,3 +1,6 @@
-def read_file(file_path: str) -> str:
+from pathlib import Path
+
+
+def read_file(file_path: str | Path) -> str:
     with open(file_path, encoding="utf-8", newline=None) as f:
         return f.read()

--- a/test/cases/comments.in.py
+++ b/test/cases/comments.in.py
@@ -2,6 +2,9 @@
 from typing import Optional
 
 
+print("\n═══ Analyse par categories (1ère catégorie) ═══\n")
+
+
 class Comment:
     SOME_CONSTANT = 1234
     ANOTHER_CONSTANT = "asdf"

--- a/test/cases/comments.out.py
+++ b/test/cases/comments.out.py
@@ -2,6 +2,9 @@
 from typing import Optional
 
 
+print("\n═══ Analyse par categories (1ère catégorie) ═══\n")
+
+
 class Comment:
     SOME_CONSTANT = 1234
     ANOTHER_CONSTANT = "asdf"

--- a/test/test_sdsort.py
+++ b/test/test_sdsort.py
@@ -1,6 +1,5 @@
 import shutil
-import tempfile
-from os import mkdir, path
+from os import mkdir
 from pathlib import Path
 
 import pytest

--- a/test/test_sdsort.py
+++ b/test/test_sdsort.py
@@ -65,7 +65,7 @@ def test_when_single_file_is_targeted_then_other_files_are_not_modified(tmp_path
     other_after = read_file(other_path)
 
     # Assert
-    assert target_after == read_file(f"{TEST_CASES_DIR}/comments.out.py"), "Target file should be sorted"
+    assert target_after == read_file(TEST_CASES_DIR / "comments.out.py"), "Target file should be sorted"
     assert other_after == read_file(other_file), "Other file should be unchanged"
 
 
@@ -114,7 +114,7 @@ def test_check_flag_reports_unsorted_files_without_modifying_them(tmp_path: Path
 
 def test_check_flag_exits_cleanly_when_files_are_already_sorted(tmp_path: Path):
     # Arrange
-    already_sorted_file = f"{TEST_CASES_DIR}/comments.out.py"
+    already_sorted_file = TEST_CASES_DIR / "comments.out.py"
     runner = CliRunner()
 
     target_path = shutil.copy(already_sorted_file, tmp_path)

--- a/test/test_sdsort.py
+++ b/test/test_sdsort.py
@@ -1,6 +1,7 @@
 import shutil
 import tempfile
 from os import mkdir, path
+from pathlib import Path
 
 import pytest
 from click.testing import CliRunner
@@ -8,7 +9,7 @@ from click.testing import CliRunner
 from sdsort import main, step_down_sort
 from sdsort.utils.file import read_file
 
-TEST_CASES_DIR = "test/cases"
+TEST_CASES_DIR = Path("test", "cases")
 
 
 @pytest.mark.parametrize(
@@ -34,8 +35,8 @@ TEST_CASES_DIR = "test/cases"
 )
 def test_all_cases(test_case: str):
     # Arrange
-    input_file_path = f"{TEST_CASES_DIR}/{test_case}.in.py"
-    expected_output_file_path = f"{TEST_CASES_DIR}/{test_case}.out.py"
+    input_file_path = TEST_CASES_DIR / f"{test_case}.in.py"
+    expected_output_file_path = TEST_CASES_DIR / f"{test_case}.out.py"
     expected_output = read_file(expected_output_file_path)
 
     # Act
@@ -46,85 +47,81 @@ def test_all_cases(test_case: str):
     assert actual_output == expected_output
 
 
-def test_when_single_file_is_targeted_then_other_files_are_not_modified():
+def test_when_single_file_is_targeted_then_other_files_are_not_modified(tmp_path: Path):
     # Arrange
-    file_to_sort = f"{TEST_CASES_DIR}/comments.in.py"
-    other_file = f"{TEST_CASES_DIR}/dataclass.in.py"
+    file_to_sort = TEST_CASES_DIR / "comments.in.py"
+    other_file = TEST_CASES_DIR / "dataclass.in.py"
     runner = CliRunner()
 
-    with tempfile.TemporaryDirectory() as temp_dir:
-        # Copy a couple of files
-        target_path = shutil.copy(file_to_sort, temp_dir)
-        other_path = shutil.copy(other_file, temp_dir)
+    # Copy a couple of files
+    target_path = shutil.copy(file_to_sort, tmp_path)
+    other_path = shutil.copy(other_file, tmp_path)
 
-        # Act
-        runner.invoke(main, [target_path])
+    # Act
+    runner.invoke(main, [str(target_path)])
 
-        # read both back
-        target_after = read_file(target_path)
-        other_after = read_file(other_path)
+    # read both back
+    target_after = read_file(target_path)
+    other_after = read_file(other_path)
 
     # Assert
     assert target_after == read_file(f"{TEST_CASES_DIR}/comments.out.py"), "Target file should be sorted"
     assert other_after == read_file(other_file), "Other file should be unchanged"
 
 
-def test_when_directory_is_provided_then_all_python_files_in_it_are_sorted():
+def test_when_directory_is_provided_then_all_python_files_in_it_are_sorted(tmp_path: Path):
     # Arrange
     test_cases = ["comments", "dataclass"]
     runner = CliRunner()
 
-    with tempfile.TemporaryDirectory() as temp_dir:
-        # Copy a couple of files
-        for tc in test_cases:
-            shutil.copy(f"{TEST_CASES_DIR}/{tc}.in.py", temp_dir)
+    # Copy a couple of files
+    for tc in test_cases:
+        shutil.copy(TEST_CASES_DIR / f"{tc}.in.py", tmp_path)
 
-        subdir_path = path.join(temp_dir, "subdir")
-        mkdir(subdir_path)
-        subdir_file_path = shutil.copy(f"{TEST_CASES_DIR}/single_class.in.py", subdir_path)
+    subdir_path = tmp_path / "subdir"
+    mkdir(subdir_path)
+    subdir_file_path = shutil.copy(TEST_CASES_DIR / "single_class.in.py", subdir_path)
 
-        # Act
-        runner.invoke(main, [temp_dir])
+    # Act
+    runner.invoke(main, [str(tmp_path)])
 
-        # Files back
-        files_after = {tc: read_file(path.join(temp_dir, f"{tc}.in.py")) for tc in test_cases}
-        files_after["single_class"] = read_file(subdir_file_path)
+    # Files back
+    files_after = {tc: read_file(tmp_path / f"{tc}.in.py") for tc in test_cases}
+    files_after["single_class"] = read_file(subdir_file_path)
 
     # Assert
     for tc, file_after in files_after.items():
-        assert file_after == read_file(f"{TEST_CASES_DIR}/{tc}.out.py")
+        assert file_after == read_file(TEST_CASES_DIR / f"{tc}.out.py")
     # TODO: assert that other files in directory were not modified?
 
 
-def test_check_flag_reports_unsorted_files_without_modifying_them():
+def test_check_flag_reports_unsorted_files_without_modifying_them(tmp_path: Path):
     # Arrange
-    file_to_sort = f"{TEST_CASES_DIR}/comments.in.py"
+    file_to_sort = TEST_CASES_DIR / "comments.in.py"
     runner = CliRunner()
 
-    with tempfile.TemporaryDirectory() as temp_dir:
-        target_path = shutil.copy(file_to_sort, temp_dir)
-        original_content = read_file(target_path)
+    target_path = shutil.copy(file_to_sort, tmp_path)
+    original_content = read_file(target_path)
 
-        # Act
-        result = runner.invoke(main, ["--check", target_path])
+    # Act
+    result = runner.invoke(main, ["--check", str(target_path)])
 
-        # Assert
-        assert result.exit_code == 1, "Exit code should be 1 when files need sorting"
-        assert "would be re-arranged" in result.output
-        assert read_file(target_path) == original_content, "File should not be modified"
+    # Assert
+    assert result.exit_code == 1, "Exit code should be 1 when files need sorting"
+    assert "would be re-arranged" in result.output
+    assert read_file(target_path) == original_content, "File should not be modified"
 
 
-def test_check_flag_exits_cleanly_when_files_are_already_sorted():
+def test_check_flag_exits_cleanly_when_files_are_already_sorted(tmp_path: Path):
     # Arrange
     already_sorted_file = f"{TEST_CASES_DIR}/comments.out.py"
     runner = CliRunner()
 
-    with tempfile.TemporaryDirectory() as temp_dir:
-        target_path = shutil.copy(already_sorted_file, temp_dir)
+    target_path = shutil.copy(already_sorted_file, tmp_path)
 
-        # Act
-        result = runner.invoke(main, ["--check", target_path])
+    # Act
+    result = runner.invoke(main, ["--check", str(target_path)])
 
-        # Assert
-        assert result.exit_code == 0, "Exit code should be 0 when files are already sorted"
-        assert "would be re-arranged" not in result.output
+    # Assert
+    assert result.exit_code == 0, "Exit code should be 0 when files are already sorted"
+    assert "would be re-arranged" not in result.output

--- a/test/test_sdsort.py
+++ b/test/test_sdsort.py
@@ -6,6 +6,7 @@ import pytest
 from click.testing import CliRunner
 
 from sdsort import main, step_down_sort
+from sdsort.utils.file import read_file
 
 TEST_CASES_DIR = "test/cases"
 
@@ -127,8 +128,3 @@ def test_check_flag_exits_cleanly_when_files_are_already_sorted():
         # Assert
         assert result.exit_code == 0, "Exit code should be 0 when files are already sorted"
         assert "would be re-arranged" not in result.output
-
-
-def read_file(file_path: str) -> str:
-    with open(file_path) as file:
-        return file.read()


### PR DESCRIPTION
Explicitly read and write files using UTF-8, because on Windows CP1252 is the default encoding (at least until https://peps.python.org/pep-0686/ lands in Python 3.15). 

Extend a test to expose the file decoding bug on Windows.

Extend the CI pipeline to run tests on Windows.

As a drive-by, improve the ruff configuration to consider and fix more rules than just import sorting.

fixes #21 