### PR TITLE
fix: Incorrect end line number for blocks that end with multi-line strings

### DIFF
--- a/sdsort/utils/ast.py
+++ b/sdsort/utils/ast.py
@@ -36,7 +36,7 @@ def find_first_line(class_or_function: ClassOrFunction, source_lines: list[str])
 
 
 def find_last_line(function: ClassOrFunction, source_lines: list[str]) -> int:
-    stop = max(n.lineno for n in walk(function) if has_lineno(n))
+    stop = max(getattr(n, "end_lineno", n.lineno) for n in walk(function) if has_lineno(n))
 
     # Probe a bit further until we find a blank line or one with less indentation than the function/class body
     def should_continue(line: str):

--- a/test/cases/multiline_string.in.py
+++ b/test/cases/multiline_string.in.py
@@ -1,0 +1,10 @@
+def _generate_markdown(full_path: str, class_name: str) -> str:
+    return f"""# {class_name}
+
+::: {full_path}
+"""
+
+
+def main() -> None:
+    result = _generate_markdown("foo.Bar", "Bar")
+    print(result)

--- a/test/cases/multiline_string.out.py
+++ b/test/cases/multiline_string.out.py
@@ -1,0 +1,10 @@
+def main() -> None:
+    result = _generate_markdown("foo.Bar", "Bar")
+    print(result)
+
+
+def _generate_markdown(full_path: str, class_name: str) -> str:
+    return f"""# {class_name}
+
+::: {full_path}
+"""

--- a/test/test_sdsort.py
+++ b/test/test_sdsort.py
@@ -31,6 +31,7 @@ TEST_CASES_DIR = Path("test", "cases")
         "sandwiched_decorator",
         "parametrized_test",
         "overloads",
+        "multiline_string",
     ],
 )
 def test_all_cases(test_case: str):


### PR DESCRIPTION
Fixes https://github.com/eirikurt/sdsort/issues/32