### PR TITLE
fix: Type alias moved beneath class it references

### DIFF
--- a/sdsort/block.py
+++ b/sdsort/block.py
@@ -1,3 +1,4 @@
+import sys
 from abc import ABC, abstractmethod
 from ast import (
     AST,
@@ -13,11 +14,20 @@ from ast import (
     ImportFrom,
     Name,
     Store,
+    iter_child_nodes,
     stmt,
     walk,
 )
 from collections.abc import Collection
 from typing import Generator, Union
+
+if sys.version_info >= (3, 12):
+    # PEP 695 `type X = ...` aliases (ast.TypeAlias) only exist on Python 3.12+.
+    from ast import TypeAlias
+
+    _TYPE_ALIAS_TYPES: tuple[type, ...] = (TypeAlias,)
+else:
+    _TYPE_ALIAS_TYPES: tuple[type, ...] = ()
 
 from .context import Context
 from .utils.ast import (
@@ -125,9 +135,17 @@ class StatementBlock(Block):
 
     def find_predecessors(self) -> Generator[str, None, None]:
         for node in self._nodes:
-            for child in walk(node):
-                if isinstance(child, Name) and child.id not in self._names:
-                    yield child.id
+            yield from self._find_predecessor_names(node)
+
+    def _find_predecessor_names(self, node: AST) -> Generator[str, None, None]:
+        # A PEP 695 `type X = <value>` alias evaluates <value> lazily, so names it
+        # references are not definition-order dependencies.
+        if isinstance(node, _TYPE_ALIAS_TYPES):
+            return
+        if isinstance(node, Name) and node.id not in self._names:
+            yield node.id
+        for child in iter_child_nodes(node):
+            yield from self._find_predecessor_names(child)
 
     def find_calls(self) -> Generator[Call, None, None]:
         yield from []

--- a/test/cases/type_declaration.in.py
+++ b/test/cases/type_declaration.in.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections import OrderedDict
+
+type MapInfo = OrderedDict[str, ParamInfo]
+
+
+class ParamInfo:
+    pass

--- a/test/cases/type_declaration.out.py
+++ b/test/cases/type_declaration.out.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections import OrderedDict
+
+type MapInfo = OrderedDict[str, ParamInfo]
+
+
+class ParamInfo:
+    pass

--- a/test/test_sdsort.py
+++ b/test/test_sdsort.py
@@ -1,5 +1,6 @@
 import ast
 import shutil
+import sys
 from os import mkdir
 from pathlib import Path
 
@@ -53,6 +54,18 @@ def test_all_cases(test_case: str):
     expected_output = read_file(expected_output_file_path)
 
     # Act
+    actual_output = step_down_sort(input_file_path)
+
+    if actual_output is None:
+        actual_output = read_file(input_file_path)
+    assert actual_output == expected_output
+
+
+@pytest.mark.skipif(sys.version_info < (3, 12), reason="`type` alias statement requires Python 3.12+")
+def test_type_alias_is_not_reordered_below_class_it_references():
+    input_file_path = TEST_CASES_DIR / "type_declaration.in.py"
+    expected_output = read_file(TEST_CASES_DIR / "type_declaration.out.py")
+
     actual_output = step_down_sort(input_file_path)
 
     if actual_output is None:


### PR DESCRIPTION
Fix a bug that would move a `type x = SomeClass` declaration below `class SomeClass`.
Such re-ordering is unnecessary because type aliases are evaluated lazily.
See https://peps.python.org/pep-0695/#lazy-evaluation