### PR TITLE
fix: Ignore type annotations of statements when their evaluation is deferred

### DIFF
--- a/sdsort/block.py
+++ b/sdsort/block.py
@@ -142,6 +142,11 @@ class StatementBlock(Block):
         # references are not definition-order dependencies.
         if isinstance(node, _TYPE_ALIAS_TYPES):
             return
+        if isinstance(node, AnnAssign) and self._context.deferred_annotations:
+            yield from self._find_predecessor_names(node.target)
+            if node.value is not None:
+                yield from self._find_predecessor_names(node.value)
+            return
         if isinstance(node, Name) and node.id not in self._names:
             yield node.id
         for child in iter_child_nodes(node):

--- a/test/cases/deferred_statement_annotation.in.py
+++ b/test/cases/deferred_statement_annotation.in.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+_STRATEGIES: dict[str, Callable[[Expr], Expr]] = {
+    "double": lambda expr: expr.add(expr),
+}
+
+
+class Expr:
+    def add(self, other: Expr) -> Expr:
+        return other

--- a/test/cases/deferred_statement_annotation.out.py
+++ b/test/cases/deferred_statement_annotation.out.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+_STRATEGIES: dict[str, Callable[[Expr], Expr]] = {
+    "double": lambda expr: expr.add(expr),
+}
+
+
+class Expr:
+    def add(self, other: Expr) -> Expr:
+        return other

--- a/test/test_sdsort.py
+++ b/test/test_sdsort.py
@@ -45,6 +45,7 @@ TEST_CASES_DIR = Path("test", "cases")
         "class_attribute_references_outer_function",
         "dangling_comment_between_defs",
         "deferred_class_attribute_annotations",
+        "deferred_statement_annotation",
     ],
 )
 def test_all_cases(test_case: str):


### PR DESCRIPTION
Fix a bug which would add a dependency from a type annotated top-level statement, even when annotations are evaluated lazily.